### PR TITLE
doesn't show loginwindow in "Top 5 Activities"

### DIFF
--- a/activity_viz.py
+++ b/activity_viz.py
@@ -42,9 +42,9 @@ def process_activities(results):
 
         if last_timestamp and last_activity:
             duration = (current_timestamp - last_timestamp).total_seconds()
-            if duration > MAX_GAP or last_activity == "loginwindow":
+            if duration > MAX_GAP or last_activity == "Idle":
                 gaps.append((last_timestamp, current_timestamp, duration))
-            elif last_activity != "loginwindow":
+            elif last_activity != "Idle":
                 activity_summary[last_activity] += duration
                 total_duration += duration
 
@@ -136,7 +136,7 @@ def summary(hours, minutes):
     activities_table.add_column("Percentage", style="green")
 
     for activity, duration in sorted(activity_summary.items(), key=lambda x: x[1], reverse=True):
-        if activity != "loginwindow":
+        if activity != "Idle":
             percentage = (duration / total_duration) * 100
             if percentage > 0.5:
                 activities_table.add_row(

--- a/main.py
+++ b/main.py
@@ -83,6 +83,11 @@ def get_active_window_info():
         workspace = NSWorkspace.sharedWorkspace()
         active_app = workspace.activeApplication()
         app_name = active_app["NSApplicationName"]
+
+        # Skip tracking when computer is idle
+        if app_name == "loginwindow":
+            return "Idle","Computer Off", None
+
         if app_name in ["Safari", "Google Chrome", "Firefox", "Brave Browser"]:
             url, title = get_browser_info(app_name)
             return app_name, title.strip(), url.strip()
@@ -102,10 +107,13 @@ def insert_activity(conn, timestamp, app_name, window_title, url, session_name, 
     ''', (timestamp, app_name, window_title, url, session_name))
     conn.commit()
 
-    # Update the activity duration
-    activity_key = extract_domain(url) if url else app_name
-    if activity_key:
-        activity_duration[activity_key] += (time.time() - previous_time)
+
+    # Skip updating duration for idle time
+    if app_name != "Idle":
+        # Update the activity duration
+        activity_key = extract_domain(url) if url else app_name
+        if activity_key:
+            activity_duration[activity_key] += (time.time() - previous_time)
 
 
 def calculate_top_activities():


### PR DESCRIPTION
"Top 5 Activities" would always be clogged with loginwindow. I don't think this is wanted. With the change, the top 5 vis doesn't display loginwindow anymore. 

<img width="238" alt="image" src="https://github.com/user-attachments/assets/34460a90-5f79-4524-a376-4c8a97652590" />

## Problem
"loginwindow" always appears in the "Top 5 Activities" which isn't meaningful for activity tracking. This made it harder to see actual computer usage patterns.

## Changes
- Changed `get_active_window_info()` to return "Idle" instead of "loginwindow"
- Top 5 activities now only show actual computer usage